### PR TITLE
Remove coffee-rails and rework coffee script to js

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ gem 'cancancan'
 
 gem "sass-rails", "~> 6.0.0"
 gem 'bootstrap-sass', '~> 3.4.1'
-gem "coffee-rails", "~> 5.0.0"
 gem "uglifier", ">= 4.2.0"
 gem "therubyracer", "~> 0.12.3"
 gem 'font-awesome-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,13 +116,6 @@ GEM
     codeclimate-test-reporter (0.4.5)
       simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.3)
-    coffee-rails (5.0.0)
-      coffee-script (>= 2.2.0)
-      railties (>= 5.2.0)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.12.2)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
     daemons (1.3.1)
@@ -426,7 +419,6 @@ DEPENDENCIES
   capybara
   chartkick (~> 2.3.5)
   codeclimate-test-reporter
-  coffee-rails (~> 5.0.0)
   database_cleaner
   devise (~> 4.7.1)
   devise-encryptable (~> 0.1.1)

--- a/app/assets/javascripts/transactions.js
+++ b/app/assets/javascripts/transactions.js
@@ -1,0 +1,6 @@
+jQuery(function() {
+  $('.best_in_place').best_in_place();
+  return $('.best_in_place').bind("ajax:success", function() {
+    return $(this).closest('tr').effect('highlight', 'slow');
+  });
+});

--- a/app/assets/javascripts/transactions.js.coffee
+++ b/app/assets/javascripts/transactions.js.coffee
@@ -1,6 +1,0 @@
-
-
-jQuery ->
-  $('.best_in_place').best_in_place()
-  $('.best_in_place').bind "ajax:success", () ->
-    $(this).closest('tr').effect('highlight', 'slow')


### PR DESCRIPTION
Issue: https://github.com/ck3g/homebugh/issues/50

The PR removes coffee-rails gem from the bundle and reworks the coffee script code to vanilla js