### PR TITLE
Added TLS in production smtp settings

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -43,8 +43,8 @@ Homebugh::Application.configure do
   config.action_mailer.default_url_options = { host: "homebugh.info" }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    enable_starttls_auto: false,
-    # port: 587,
+      port: 587,
+      enable_starttls_auto: true,
     # address: "smtp.mailgun.org",
     # domain: 'mg.homebugh.info',
     # user_name: ENV['MAILGUN_USER'],


### PR DESCRIPTION
According to the documentation of ActionMailer ":ssl/:tls - Enables the SMTP connection to use SMTP/TLS (SMTPS: SMTP over direct TLS connection)". But port 587 is not for direct TLS but for TLS upgrade via the STARTTLS command. 

To solve the problem either use port 465 with tls (if enabled on the server) or use port 587 and rely on enable_starttls_auto that it will do a later upgrade to TLS.

Please suggest anyone @ck3g according to the server.