### PR TITLE
Create PR template with Hacktoberfest rules

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+Fixes # .
+
+Changes proposed in this pull request:
+
+-
+-
+-
+
+<!--
+
+Thanks for creating the pull request!
+
+Notice for the Hacktoberfest contributors from FAQ Rules section:
+
+> Pull requests created before Oct 1 but merged or marked as ready for review after do not count.
+
+https://hacktoberfest.digitalocean.com/faq
+
+-->


### PR DESCRIPTION
Adds a PR template with the notice that

> Pull requests created before Oct 1 but merged or marked as ready for review after do not count.