### PR TITLE
Fix flaky test

### DIFF
--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -9,7 +9,7 @@ class Budget < ActiveRecord::Base
   def expenses(date: Date.current)
     user.transactions
       .joins(:account)
-      .where(created_at: date.beginning_of_month..date.end_of_month)
+      .where(created_at: date.to_time.beginning_of_month..date.to_time.end_of_month)
       .where(category_id: category.id)
       .where(:'accounts.currency_id' => currency.id)
       .pluck(:summ).sum


### PR DESCRIPTION
`date.end_of_month` returns the date without time, that ignores all the records created on the last day of the month.

`date.to_time.end_of_month` returns last second of the day.

