### PR TITLE
Update view /users/edit to prevent changing credentials for the demo_user

### DIFF
--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -2,9 +2,14 @@
 = simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: "form-horizontal" }) do |f|
   = f.error_notification
   .form-inputs
-    = f.input :email, required: true, autofocus: true
-    = f.input :password, autocomplete: "off", hint: t("devise.registrations.leave_it_blank_if_dont_want_to_change"), required: false
-    = f.input :password_confirmation, required: false
-    = f.input :current_password, hint: t("devise.registrations.need_current_password_to_confirm"), required: true
-  .form-actions
-    = f.button :submit, t('common.update'), class: "btn btn-primary"
+    - if current_user.demo_user?
+      = f.input :email, required: false, autofocus: false, :input_html => { readonly: :true, :value => 'demo@homebugh.info' }
+      = f.input :password, autocomplete: "off", hint: t("devise.registrations.demo_user_account_defaults"), required: false, :input_html => { readonly: :true, :value => 'demo1234' }
+    - else
+      = f.input :email, required: true, autofocus: true
+      = f.input :password, autocomplete: "off", hint: t("devise.registrations.leave_it_blank_if_dont_want_to_change"), required: false
+      = f.input :password_confirmation, required: false
+      = f.input :current_password, hint: t("devise.registrations.need_current_password_to_confirm"), required: true
+      .form-actions
+        = f.button :submit, t(:update), class: "btn btn-primary"
+

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -3,8 +3,8 @@
   = f.error_notification
   .form-inputs
     - if current_user.demo_user?
-      = f.input :email, required: false, autofocus: false, :input_html => { readonly: :true, :value => 'demo@homebugh.info' }
-      = f.input :password, autocomplete: "off", hint: t("devise.registrations.demo_user_account_defaults"), required: false, :input_html => { readonly: :true, :value => 'demo1234' }
+      = f.input :email, required: false, autofocus: false, input_html: { readonly: true, value: current_user.email }
+      = f.input :password, autocomplete: "off", required: false, input_html: { readonly: true, value: 'demouser', type: 'text' }
     - else
       = f.input :email, required: true, autofocus: true
       = f.input :password, autocomplete: "off", hint: t("devise.registrations.leave_it_blank_if_dont_want_to_change"), required: false


### PR DESCRIPTION
Fixes https://github.com/ck3g/homebugh/issues/35

Changes proposed in this pull request:

- Checks whether the demo_user has signed in or not in the users/edit template to alter the view and prevent the user modify its credentials by:
  - Making the inputs[ :email, password] readonly and displaying default values.
  - Disabling the submit POST method.

<!--

Thanks for creating the pull request!

Notice for the Hacktoberfest contributors from FAQ Rules section:

> Pull requests created before Oct 1 but merged or marked as ready for review after do not count.

https://hacktoberfest.digitalocean.com/faq

-->
