### PR TITLE
Remove Hacktoberfest hint from the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,10 +10,4 @@ Changes proposed in this pull request:
 
 Thanks for creating the pull request!
 
-Notice for the Hacktoberfest contributors from FAQ Rules section:
-
-> Pull requests created before Oct 1 but merged or marked as ready for review after do not count.
-
-https://hacktoberfest.digitalocean.com/faq
-
 -->


### PR DESCRIPTION
The hint is not relevant anymore after Oct 1st

