### PR TITLE
Add next payment on to recurring payments

### DIFF
--- a/app/controllers/recurring_payments_controller.rb
+++ b/app/controllers/recurring_payments_controller.rb
@@ -32,6 +32,6 @@ class RecurringPaymentsController < ApplicationController
   end
 
   def create_params
-    params.require(:recurring_payment).permit(:title, :account_id, :category_id, :amount, :frequency, :frequency_amount)
+    params.require(:recurring_payment).permit(:title, :account_id, :category_id, :amount, :frequency, :frequency_amount, :next_payment_on)
   end
 end

--- a/app/decorators/recurring_payment_decorator.rb
+++ b/app/decorators/recurring_payment_decorator.rb
@@ -5,6 +5,10 @@ class RecurringPaymentDecorator < Draper::Decorator
     h.get_number_to_currency object.amount, unit
   end
 
+  def next_payment_on
+    I18n.l(object.next_payment_on, format: :long)
+  end
+
   def created_on
     I18n.l(object.created_at.to_date, format: :long)
   end

--- a/app/models/recurring_payment.rb
+++ b/app/models/recurring_payment.rb
@@ -3,12 +3,21 @@ class RecurringPayment < ApplicationRecord
   belongs_to :category
   belongs_to :account
 
-  validates :title, :user, :category, :account, presence: true
+  validates :title, :user, :category, :account, :next_payment_on, presence: true
   validates :amount, presence: true, numericality: { greater_than_or_equal_to: 0.01 }
   validates :frequency_amount, presence: true, numericality: { greater_than_or_equal_to: 1, only_integer: true }
+  validate :ensure_next_payment_on_is_in_the_future
 
   enum frequency: { daily: 0, weekly: 1, monthly: 2, yearly: 3 }
 
   delegate :name, to: :category, prefix: true
   delegate :name, to: :account, prefix: true
+
+  private
+
+  def ensure_next_payment_on_is_in_the_future
+    if next_payment_on.present? && next_payment_on < Date.today
+      errors.add(:next_payment_on, "cannot be in the past")
+    end
+  end
 end

--- a/app/views/recurring_payments/_form.html.haml
+++ b/app/views/recurring_payments/_form.html.haml
@@ -7,6 +7,7 @@
   = f.input :amount
   = f.input :frequency, collection: recurring_payment_frequencies_collection, as: :select
   = f.input :frequency_amount
+  = f.input :next_payment_on, as: :date, start_year: Date.today.year, order: [:day, :month, :year], input_html: { class: 'date-select' }
   .col-lg-offset-2.col-lg-10
     = f.button :submit, class: "btn btn-primary", id: :recurring_payment_submit
     = link_to t("common.back"), recurring_payments_path, class: "btn"

--- a/app/views/recurring_payments/index.html.haml
+++ b/app/views/recurring_payments/index.html.haml
@@ -20,7 +20,7 @@
             - @recurring_payments.each do |recurring_payment|
               %tr{id: dom_id(recurring_payment)}
                 %td.span2= recurring_payment.title
-                %td= recurring_payment.decorate.created_on
+                %td= recurring_payment.decorate.next_payment_on
                 %td.span2.number
                   = recurring_payment.decorate.amount
                 %td.span2= recurring_payment.account_name

--- a/db/migrate/20201006072040_add_next_payment_on_to_recurring_payments.rb
+++ b/db/migrate/20201006072040_add_next_payment_on_to_recurring_payments.rb
@@ -1,0 +1,5 @@
+class AddNextPaymentOnToRecurringPayments < ActiveRecord::Migration[6.0]
+  def change
+    add_column :recurring_payments, :next_payment_on, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_01_090753) do
+ActiveRecord::Schema.define(version: 2020_10_06_072040) do
 
   create_table "accounts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", limit: 50, null: false
@@ -100,6 +100,7 @@ ActiveRecord::Schema.define(version: 2020_10_01_090753) do
     t.integer "frequency", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.date "next_payment_on"
     t.index ["account_id"], name: "index_recurring_payments_on_account_id"
     t.index ["category_id"], name: "index_recurring_payments_on_category_id"
     t.index ["user_id"], name: "index_recurring_payments_on_user_id"

--- a/spec/factories/recurring_payments.rb
+++ b/spec/factories/recurring_payments.rb
@@ -9,5 +9,6 @@ FactoryBot.define do
     amount 503
     frequency_amount 1
     frequency 2
+    next_payment_on { 1.month.from_now.to_date }
   end
 end

--- a/spec/features/recurring_payments/create_recurring_payment_spec.rb
+++ b/spec/features/recurring_payments/create_recurring_payment_spec.rb
@@ -26,7 +26,7 @@ feature 'Create Recurring Payment' do
     select 'Cash [$]', from: 'recurring_payment_account_id'
     select 'Services', from: 'recurring_payment_category_id'
     fill_in 'recurring_payment_amount', with: 10
-    # TODO: select next payment
+    select_next_payment_date(20.days.from_now.to_date)
     select 'Weekly', from: 'recurring_payment_frequency'
     fill_in 'recurring_payment_frequency_amount', with: 2
     click_button 'recurring_payment_submit'
@@ -42,5 +42,12 @@ feature 'Create Recurring Payment' do
     expect(rp.amount).to eq(10)
     expect(rp.frequency).to eq('weekly')
     expect(rp.frequency_amount).to eq(2)
+    expect(rp.next_payment_on).to eq(20.days.from_now.to_date)
   end
+end
+
+def select_next_payment_date(date)
+  select date.day, from: 'recurring_payment_next_payment_on_3i'
+  select date.strftime("%B"), from: 'recurring_payment_next_payment_on_2i'
+  select date.year, from: 'recurring_payment_next_payment_on_1i'
 end

--- a/spec/features/recurring_payments_list_spec.rb
+++ b/spec/features/recurring_payments_list_spec.rb
@@ -23,8 +23,8 @@ feature "Recurring Payments list" do
   end
 
   scenario "logged in users can see list of their existing recurring payments" do
-    create(:recurring_payment, title: "User's rent", user: user, category: category, account: account, amount: 500)
-    create(:recurring_payment, title: "Other's rent")
+    rp1 = create(:recurring_payment, title: "User's rent", user: user, category: category, account: account, amount: 500)
+    rp2 = create(:recurring_payment, title: "Other's rent")
 
     sign_in_as 'user@example.com', 'password'
 
@@ -33,7 +33,10 @@ feature "Recurring Payments list" do
     expect(current_path).to eq recurring_payments_path
     expect(page).not_to have_content "You have no recurring payments yet."
 
-    expect(page).to have_content "User's rent"
-    expect(page).not_to have_content "Others's rent"
+    within "#recurring_payment_#{rp1.id}" do
+      expect(page).to have_content "User's rent #{rp1.decorate.next_payment_on}"
+    end
+
+    expect(page).not_to have_content "Others's rent #{rp2.decorate.next_payment_on}"
   end
 end

--- a/spec/models/recurring_payment_spec.rb
+++ b/spec/models/recurring_payment_spec.rb
@@ -27,6 +27,24 @@ RSpec.describe RecurringPayment, type: :model do
           .is_greater_than_or_equal_to(1)
           .only_integer
       end
+
+      it { is_expected.to validate_presence_of(:next_payment_on) }
+
+      it 'when next payment on is in the future' do
+        rp = build_stubbed(:recurring_payment, next_payment_on: 1.day.from_now.to_date)
+        expect(rp).to be_valid
+      end
+
+      it 'when next payment on is today' do
+        rp = build_stubbed(:recurring_payment, next_payment_on: Date.today)
+        expect(rp).to be_valid
+      end
+
+      it 'when next payment on is in the past' do
+        rp = build_stubbed(:recurring_payment, next_payment_on: 1.day.ago.to_date)
+        expect(rp).to be_invalid
+        expect(rp.errors.full_messages_for(:next_payment_on)).to eq(["Next payment on cannot be in the past"])
+      end
     end
   end
 


### PR DESCRIPTION
Implements https://github.com/ck3g/homebugh/issues/86

Changes proposed in this pull request:

- Adds `recurring_payments.next_payment_on` column
- Validates the presence and ensure the date is not in the past
- Adds "next payment" to create form
- Displays "next payment" in the list of recurring payments


