### PR TITLE
allow update show in summary in account edit page

### DIFF
--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -33,3 +33,69 @@ ul.site-links {
 .nav .active a {
   border-bottom: 4px solid #47a447;
 }
+
+.edit-profile {
+  margin-top: 10px;
+  float: right;
+}
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 52px;
+  height: 26px;
+  top: 5px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  -webkit-transition: .4s;
+  transition: .4s;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 18px;
+  width: 18px;
+  left: 4px;
+  bottom: 4px;
+  background-color: white;
+  -webkit-transition: .4s;
+  transition: .4s;
+}
+
+input:checked + .slider {
+  background-color: #2196F3;
+}
+
+input:focus + .slider {
+  box-shadow: 0 0 1px #2196F3;
+}
+
+input:checked + .slider:before {
+  -webkit-transform: translateX(26px);
+  -ms-transform: translateX(26px);
+  transform: translateX(26px);
+}
+
+/* Rounded sliders */
+.slider.round {
+  border-radius: 34px;
+}
+
+.slider.round:before {
+  border-radius: 50%;
+}

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -39,6 +39,6 @@ class AccountsController < ApplicationController
   end
 
   def safe_params
-    params.require(:account).permit(:name, :currency_id)
+    params.require(:account).permit(:name, :currency_id, :show_in_summary)
   end
 end

--- a/app/views/accounts/_form.html.haml
+++ b/app/views/accounts/_form.html.haml
@@ -1,7 +1,12 @@
 = simple_form_for account, html: { class: "form-horizontal" } do |f|
   = f.input :name, input_html: { class: 'medium-input' }
   = f.association :currency, include_blank: false, input_html: { class: 'medium-input' }
+  = f.label :show_in_summary
+  %label.switch
+    = f.check_box :show_in_summary
+    %span.slider.round
   .form-group.action-buttons
     .col-sm-offset-2.col-sm-10
       = f.button :submit, class: "btn btn-primary", id: :account_submit
       = link_to t("common.back"), accounts_path, class: "btn"
+


### PR DESCRIPTION
Fixes #59 

Changes proposed in this pull request:

- Allow to update `show_in_summary` value on edit account page
![Peek 2020-10-09 16-28](https://user-images.githubusercontent.com/47997261/95566957-7c0dbf00-0a4c-11eb-9034-d14ab5cb2e8f.gif)

<!--

Thanks for creating the pull request!

-->
