### PR TITLE
Order recurring payments by due date

### DIFF
--- a/app/controllers/recurring_payments_controller.rb
+++ b/app/controllers/recurring_payments_controller.rb
@@ -4,7 +4,7 @@ class RecurringPaymentsController < ApplicationController
   before_action :find_recurring_payment, only: [:edit, :update, :destroy]
 
   def index
-    @recurring_payments = current_user.recurring_payments
+    @recurring_payments = current_user.recurring_payments.upcoming
   end
 
   def new

--- a/app/models/recurring_payment.rb
+++ b/app/models/recurring_payment.rb
@@ -14,6 +14,8 @@ class RecurringPayment < ApplicationRecord
   delegate :name, to: :category, prefix: true
   delegate :name, to: :account, prefix: true
 
+  scope :upcoming, -> { order(:next_payment_on) }
+
   private
 
   def ensure_next_payment_on_is_in_the_future

--- a/spec/models/recurring_payment_spec.rb
+++ b/spec/models/recurring_payment_spec.rb
@@ -52,6 +52,18 @@ RSpec.describe RecurringPayment, type: :model do
     is_expected.to define_enum_for(:frequency).with_values(daily: 0, weekly: 1, monthly: 2, yearly: 3)
   end
 
+  describe '.upcoming' do
+    subject { described_class.upcoming }
+
+    let!(:due_today) { create(:recurring_payment, next_payment_on: Date.today) }
+    let!(:due_one_month) { create(:recurring_payment, next_payment_on: 1.month.from_now) }
+    let!(:due_one_week) { create(:recurring_payment, next_payment_on: 1.week.from_now) }
+
+    it 'orders by closest due date' do
+      is_expected.to eq([due_today, due_one_week, due_one_month])
+    end
+  end
+
   describe '#income?' do
     subject { build_stubbed(:recurring_payment, category: category ) }
 


### PR DESCRIPTION
Orders the recurring payments so the payments with the closest next payment are displayed first