### PR TITLE
Add cookie consent modal dialog

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,6 +8,7 @@
 //= require best_in_place
 //= require select2
 //= require select2_locale_ru
+//= require js.cookie
 //= require chartkick
 //= require_self
 //= require_tree .

--- a/app/assets/javascripts/cookie_consent.js
+++ b/app/assets/javascripts/cookie_consent.js
@@ -1,0 +1,20 @@
+jQuery(window).on('load', function(){
+  new CookieConsent().check();
+});
+
+class CookieConsent {
+  constructor () {
+    $('#cookie-consent-button-ok').off('click').on('click', function() {
+      Cookies.set('cookie_consent_accepted', true, { expires: 36500 });
+    });
+  }
+
+  check() {
+    const isAccepted = Cookies.get('cookie_consent_accepted');
+
+    if(!isAccepted) {
+      $('#cookie-consent-modal').modal('show');
+    }
+  }
+}
+

--- a/app/assets/javascripts/welcome.js
+++ b/app/assets/javascripts/welcome.js
@@ -3,4 +3,5 @@
 //= require jquery
 //= require bootstrap
 //= require_self
-
+//= require js.cookie
+//= require cookie_consent

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -31,3 +31,4 @@
           %footer
             = render 'shared/footer'
     = render 'shared/analytics'
+  = render 'shared/cookie_consent_modal'

--- a/app/views/layouts/welcome.html.haml
+++ b/app/views/layouts/welcome.html.haml
@@ -15,3 +15,4 @@
 
     = javascript_include_tag :welcome
     = render 'shared/analytics'
+    = render 'shared/cookie_consent_modal'

--- a/app/views/shared/_cookie_consent_modal.html.haml
+++ b/app/views/shared/_cookie_consent_modal.html.haml
@@ -1,0 +1,14 @@
+.modal.fade#cookie-consent-modal{ tabindex: "-1", role: "dialog" }
+  .modal-dialog{ role: "document" }
+    .modal-content
+      .modal-header
+        %button.close{ type: "button", 'data-dismiss': "modal" }
+          %span
+            &times;
+        %h4.modal-title
+          = t('cookie_consent.title')
+      .modal-body
+        = t('cookie_consent.text')
+      .modal-footer
+        %button.btn.btn-primary{ id: 'cookie-consent-button-ok', type: "button", 'data-dismiss': "modal" }
+          = t('cookie_consent.button_text')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -201,6 +201,11 @@ en:
   search_categories: Search categories
   search: Search
 
+  cookie_consent:
+    title: 'Cookie Consent'
+    text:  'We use cookies to give you the best online experience. By using our website, you agree to our use of cookies.'
+    button_text: 'OK'
+
   check_list:
     title: "First steps"
     account:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -248,6 +248,11 @@ ru:
   search_categories: Поиск категорий
   search: Найти
 
+  cookie_consent:
+    title: 'Согласие на использование файлов cookies'
+    text:  'Мы используем файлы cookies, чтобы сделать сайт более удобным в использовании. Продолжая использовать сайт, вы соглашаетесь с использованием файлов cookies.'
+    button_text: 'OK'
+
   check_list:
     title: "Первые шаги"
     account:

--- a/vendor/assets/javascripts/js.cookie.js
+++ b/vendor/assets/javascripts/js.cookie.js
@@ -1,0 +1,142 @@
+/*! js-cookie v3.0.0-rc.1 | MIT */
+;
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+  typeof define === 'function' && define.amd ? define(factory) :
+  (global = global || self, (function () {
+    var current = global.Cookies;
+    var exports = global.Cookies = factory();
+    exports.noConflict = function () { global.Cookies = current; return exports; };
+  }()));
+}(this, (function () { 'use strict';
+
+  function assign (target) {
+    for (var i = 1; i < arguments.length; i++) {
+      var source = arguments[i];
+      for (var key in source) {
+        target[key] = source[key];
+      }
+    }
+    return target
+  }
+
+  var defaultConverter = {
+    read: function (value) {
+      return value.replace(/(%[\dA-F]{2})+/gi, decodeURIComponent)
+    },
+    write: function (value) {
+      return encodeURIComponent(value).replace(
+        /%(2[346BF]|3[AC-F]|40|5[BDE]|60|7[BCD])/g,
+        decodeURIComponent
+      )
+    }
+  };
+
+  function init (converter, defaultAttributes) {
+    function set (key, value, attributes) {
+      if (typeof document === 'undefined') {
+        return
+      }
+
+      attributes = assign({}, defaultAttributes, attributes);
+
+      if (typeof attributes.expires === 'number') {
+        attributes.expires = new Date(Date.now() + attributes.expires * 864e5);
+      }
+      if (attributes.expires) {
+        attributes.expires = attributes.expires.toUTCString();
+      }
+
+      key = encodeURIComponent(key)
+        .replace(/%(2[346B]|5E|60|7C)/g, decodeURIComponent)
+        .replace(/[()]/g, escape);
+
+      value = converter.write(value, key);
+
+      var stringifiedAttributes = '';
+      for (var attributeName in attributes) {
+        if (!attributes[attributeName]) {
+          continue
+        }
+
+        stringifiedAttributes += '; ' + attributeName;
+
+        if (attributes[attributeName] === true) {
+          continue
+        }
+
+        // Considers RFC 6265 section 5.2:
+        // ...
+        // 3.  If the remaining unparsed-attributes contains a %x3B (";")
+        //     character:
+        // Consume the characters of the unparsed-attributes up to,
+        // not including, the first %x3B (";") character.
+        // ...
+        stringifiedAttributes += '=' + attributes[attributeName].split(';')[0];
+      }
+
+      return (document.cookie = key + '=' + value + stringifiedAttributes)
+    }
+
+    function get (key) {
+      if (typeof document === 'undefined' || (arguments.length && !key)) {
+        return
+      }
+
+      // To prevent the for loop in the first place assign an empty array
+      // in case there are no cookies at all.
+      var cookies = document.cookie ? document.cookie.split('; ') : [];
+      var jar = {};
+      for (var i = 0; i < cookies.length; i++) {
+        var parts = cookies[i].split('=');
+        var value = parts.slice(1).join('=');
+
+        if (value[0] === '"') {
+          value = value.slice(1, -1);
+        }
+
+        try {
+          var foundKey = defaultConverter.read(parts[0]);
+          jar[foundKey] = converter.read(value, foundKey);
+
+          if (key === foundKey) {
+            break
+          }
+        } catch (e) {}
+      }
+
+      return key ? jar[key] : jar
+    }
+
+    return Object.create(
+      {
+        set: set,
+        get: get,
+        remove: function (key, attributes) {
+          set(
+            key,
+            '',
+            assign({}, attributes, {
+              expires: -1
+            })
+          );
+        },
+        withAttributes: function (attributes) {
+          return init(this.converter, assign({}, this.attributes, attributes))
+        },
+        withConverter: function (converter) {
+          return init(assign({}, this.converter, converter), this.attributes)
+        }
+      },
+      {
+        attributes: { value: Object.freeze(defaultAttributes) },
+        converter: { value: Object.freeze(converter) }
+      }
+    )
+  }
+
+  var api = init(defaultConverter, { path: '/' });
+
+  return api;
+
+})));


### PR DESCRIPTION
Fixes #53  .

Changes proposed in this pull request:

- Add js-cookie lib to get and set cookies;
- Add _cookie_consent_modal.html.haml shared view to render modal html;
- Add logic to show/hide modal and check if consent accepted.

<!--

Thanks for creating the pull request!

-->
