### PR TITLE
Prevent updating demo user

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -23,4 +23,24 @@ class RegistrationsController < Devise::RegistrationsController
       respond_with resource
     end
   end
+
+  def update
+    self.resource = resource_class.to_adapter.get!(send(:"current_#{resource_name}").to_key)
+    prev_unconfirmed_email = resource.unconfirmed_email if resource.respond_to?(:unconfirmed_email)
+
+    acc_params = resource.demo_user? ? {} : account_update_params
+
+    resource_updated = update_resource(resource, acc_params)
+    yield resource if block_given?
+    if !resource.demo_user? && resource_updated
+      set_flash_message_for_update(resource, prev_unconfirmed_email)
+      bypass_sign_in resource, scope: resource_name if sign_in_after_change_password?
+
+      respond_with resource, location: after_update_path_for(resource)
+    else
+      clean_up_passwords resource
+      set_minimum_password_length
+      respond_with resource
+    end
+  end
 end

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe RegistrationsController, type: :controller do
+  describe 'PUT #update' do
+    subject(:update) { put :update, params: { user: user_params } }
+
+    let(:user_params) do
+      {
+        email: 'new-user-email@example.com',
+        password: 'new-password',
+        password_confirmation: 'new-password',
+        current_password: 'password'
+      }
+    end
+
+    context 'with regular user' do
+      login_user
+
+      it 'changes user email' do
+        expect { update }.to change { User.last!.email }.to 'new-user-email@example.com'
+      end
+
+      it 'changes user password' do
+        update
+
+        expect(User.last!.valid_password?('new-password')).to be_truthy
+      end
+    end
+
+    context 'with demo user' do
+      login_demo_user
+
+      it 'does not change user email' do
+        expect { update }.not_to change { User.last!.email }
+      end
+
+      it 'does not change user password' do
+        update
+
+        expect(User.last!.valid_password?('new-password')).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -9,5 +9,9 @@ FactoryBot.define do
     factory :user_example_com do
       email { 'user@example.com' }
     end
+
+    trait :demo_user do
+      demo_user { true }
+    end
   end
 end

--- a/spec/support/login_macros.rb
+++ b/spec/support/login_macros.rb
@@ -9,9 +9,14 @@ module LoginMacros
   def login_user
     before(:each) do
       @request.env["devise.mapping"] = Devise.mappings[:user]
-      user = FactoryBot.create(:user)
-      sign_in user
+      sign_in FactoryBot.create(:user)
     end
   end
 
+  def login_demo_user
+    before(:each) do
+      @request.env["devise.mapping"] = Devise.mappings[:user]
+      sign_in FactoryBot.create(:user, :demo_user)
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/ck3g/homebugh/issues/36

Overrides `Devise::RegistrationController#update` action and prevent updating demo users